### PR TITLE
builtins.path expects path, not src

### DIFF
--- a/source/anti-patterns/language.rst
+++ b/source/anti-patterns/language.rst
@@ -171,7 +171,7 @@ A better way is to use ``builtins.path``:
    pkgs.stdenv.mkDerivation {
      name = "foobar";
 
-     src = builtins.path { src = ./.; name = "myproject"; };
+     src = builtins.path { path = ./.; name = "myproject"; };
   }
 
 


### PR DESCRIPTION
I was incorporating this and was scratching my head on why
```
error: error: --- EvalError ----------------------------------------------------------------------------------------------------------------------------------------------------- nix
in file: (string) (1:18)

unsupported argument 'src' to 'addPath'

```